### PR TITLE
Return a 500 status code.

### DIFF
--- a/index.js
+++ b/index.js
@@ -57,7 +57,7 @@ module.exports = function(err, req, res, next) {
 
     console.error(prettifyError(err) || err.stack);
 
-    res.send(render({
+    res.status(500).send(render({
       err: err,
       lines: lines
     }));


### PR DESCRIPTION
If the site errors, it should throw a 500.