### PR TITLE
Upgrade and move express to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "description": "Error-handling Express middleware that displays syntax highlighted source code.",
   "main": "server.js",
   "dependencies": {
-    "express": "~4.0.0-rc4",
     "stack-trace": "0.0.9",
     "async-each": "~0.1.4",
     "errto": "~0.2.1",
@@ -12,7 +11,9 @@
     "ejs": "~1.0.0",
     "highlight.js": "https://github.com/alessioalex/highlight.js/releases/download/npm-v0.1.1/highlight.js.tar.gz.tgz"
   },
-  "devDependencies": {},
+  "devDependencies": {
+    "express": "^4.13.3"
+  },
   "keywords": ["express", "error", "error-handler", "errorhandler"],
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",


### PR DESCRIPTION
[Requiresafe](https://requiresafe.com/) reported several vulnerabilities in the version of express that got pulled in when installing this module as a dependency.

I've upgraded express to current latest and moved it to the devDependencies (as it seems to be used only in the examples)
